### PR TITLE
Refactor and Prevent Column Type bit(1)

### DIFF
--- a/SQL/000_anastasia_schema.sql
+++ b/SQL/000_anastasia_schema.sql
@@ -576,7 +576,7 @@ CREATE TABLE `privacy` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ckey` varchar(32) NOT NULL,
   `datetime` datetime NOT NULL,
-  `consent` bit(1) NOT NULL,
+  `consent` tinyint(1) NOT NULL,
   `date_created` datetime NOT NULL DEFAULT current_timestamp(),
   `date_updated` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `uuid` uuid NOT NULL DEFAULT uuid(),

--- a/bin/dump-game-db
+++ b/bin/dump-game-db
@@ -19,8 +19,9 @@ docker run \
     --tty=true \
     mariadb:latest \
     mariadb-dump \
+    --complete-insert \
     --host 127.0.0.1 \
     --user root \
-    -p${SQL_ROOT_PASSWORD} \
+    --password="${SQL_ROOT_PASSWORD}" \
     ${SQL_DATABASE} \
     > "${OUTPUT_FILE}"

--- a/testdata/SQL/001a_test_data.sql
+++ b/testdata/SQL/001a_test_data.sql
@@ -1,0 +1,14 @@
+-- 001a_test_data.sql
+
+--
+-- Insert some test data
+--
+
+INSERT INTO `characters` (`id`, `ckey`, `slot`, `OOC_Notes`, `real_name`, `name_is_always_random`, `gender`, `age`, `species`, `language`, `hair_colour`, `secondary_hair_colour`, `facial_hair_colour`, `secondary_facial_hair_colour`, `skin_tone`, `skin_colour`, `marking_colours`, `head_accessory_colour`, `hair_style_name`, `facial_style_name`, `marking_styles`, `head_accessory_style_name`, `alt_head_name`, `eye_colour`, `underwear`, `undershirt`, `backbag`, `b_type`, `alternate_option`, `job_support_high`, `job_support_med`, `job_support_low`, `job_medsci_high`, `job_medsci_med`, `job_medsci_low`, `job_engsec_high`, `job_engsec_med`, `job_engsec_low`, `job_karma_high`, `job_karma_med`, `job_karma_low`, `flavor_text`, `med_record`, `sec_record`, `gen_record`, `disabilities`, `player_alt_titles`, `organ_data`, `rlimb_data`, `nanotrasen_relation`, `speciesprefs`, `socks`, `body_accessory`, `gear`, `autohiss`, `date_created`, `date_updated`, `uuid`, `version`)
+VALUES (1,'veloxi',1,'','Katlyn Hudson',0,'female',26,'Human','None','#ffff99','#000000','#ffff99','#000000',34,'#ffffcc','head=%23000000&body=%23000000&tail=%23000000','#000000','Spiky Ponytail','Shaved','head=None&body=Hive+Tattoo&tail=None','None','None','#0000ff','Ladies Black','I Love NT Shirt','Department Backpack','A+',2,0,0,4114,0,20,0,1,0,528,0,0,0,'','','','',0,'','','','Loyal',0,'Pantyhose','','lipstick%2c+red&Gold+ring&dress+shoes',0,'2025-01-18 21:30:24','2025-01-18 21:31:02','6d978a57-d5e3-11ef-bb75-0242ac110002',0);
+
+INSERT INTO `player` (`id`, `ckey`, `firstseen`, `lastseen`, `ip`, `computerid`, `lastadminrank`, `ooccolor`, `UI_style`, `UI_style_color`, `UI_style_alpha`, `be_role`, `default_slot`, `toggles`, `toggles_2`, `sound`, `volume_mixer`, `lastchangelog`, `exp`, `clientfps`, `atklog`, `fuid`, `fupdate`, `parallax`, `byond_date`, `2fa_status`, `date_created`, `date_updated`, `uuid`, `version`)
+VALUES (1,'veloxi','2025-01-18 21:25:59','2025-01-20 22:26:15','127.0.0.1','1234567890','Host','#b82e00','Midnight','#ffffff',255,'',1,14721343,4558,4079,'{\"1024\":100,\"1023\":100,\"1022\":100,\"1021\":100,\"1020\":100,\"1019\":100,\"1018\":100,\"1017\":100}','0',NULL,0,0,NULL,0,8,'2018-02-17','DISABLED','2025-01-18 21:25:59','2025-01-20 22:26:15','cf8e5157-d5e2-11ef-bb75-0242ac110002',0);
+
+INSERT INTO `privacy` (`id`, `ckey`, `datetime`, `consent`, `date_created`, `date_updated`, `uuid`, `version`)
+VALUES (1,'veloxi','2025-01-20 22:26:21',1,'2025-01-20 22:26:21','2025-01-20 22:26:21','9364a265-d77d-11ef-9a1e-0242ac110002',0);

--- a/tools/ci/check_game_database.sh
+++ b/tools/ci/check_game_database.sh
@@ -113,6 +113,11 @@ query_text="select t.table_name from information_schema.tables t left join infor
 query_result=$(query "$query_text")
 expect_empty "$query_text" "$query_result"
 
+# Ensure no tables have a column of type `bit(1)`
+query_text="select table_name, column_name from information_schema.columns where table_schema = 'anastasia_gamedb' and data_type = 'bit' and character_maximum_length = 1;"
+query_result=$(query "$query_text")
+expect_empty "$query_text" "$query_result"
+
 
 # exit with error if any check failed
 if [[ $error_flag -ne 0 ]]; then

--- a/tools/ci/check_game_database.sh
+++ b/tools/ci/check_game_database.sh
@@ -114,7 +114,7 @@ query_result=$(query "$query_text")
 expect_empty "$query_text" "$query_result"
 
 # Ensure no tables have a column of type `bit(1)`
-query_text="select table_name, column_name from information_schema.columns where table_schema = 'anastasia_gamedb' and data_type = 'bit' and character_maximum_length = 1;"
+query_text="select table_name, column_name from information_schema.columns where table_schema = 'anastasia_gamedb' and data_type = 'bit';"
 query_result=$(query "$query_text")
 expect_empty "$query_text" "$query_result"
 


### PR DESCRIPTION
When attempting to run INSERT commands from a database dump, I noticed an error.
It seems the `bit(1)` column was dumped as `'^A'` which is a Ctrl+A which is 0x01.

The INSERT command was rejected with the error:
> ERROR 1406 (22001): Data too long for column 'consent' at row 1

Looking into it a little more, it appears `bit(1)` just sucks.
https://stackoverflow.com/a/73697808

Moreover, except for column `consent` on table `privacy`, all the other true/false values saved in the database use `tinyint(1)` instead.

This PR will refactor the consent column to `tinyint(1)` and add a QA check to prevent `bit(1)` columns from being accidentally added in the future.