### PR TITLE
Tag and Release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,9 @@ jobs:
   publish:
     name: "Publish Docker Image"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Checkout Project
       uses: actions/checkout@v4

--- a/tools/semver.py
+++ b/tools/semver.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+import datetime
+print(f"{datetime.date.today().year - 2025}.{datetime.date.today().isocalendar()[1]}.x")


### PR DESCRIPTION
This PR fixes a bug in the CD workflow; without permissions, it can't publish packages (i.e.: container images)

This PR also creates a tiny Python script to help figure out what the current version ought to be (-ish)
