### PR TITLE
Container uid To Match Provisioning uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN dpkg --add-architecture i386 \
     zlib1g:i386 \
     libstdc++6:i386 \
     && rm -rf /var/lib/apt/lists/*
-RUN useradd -ms /bin/bash ss13
+RUN useradd --uid 1002 --gid 1002 --create-home --shell /bin/bash ss13
 COPY --chown=ss13:ss13 --from=byond_build /build/_maps /anastasia/_maps
 COPY --chown=ss13:ss13 --from=byond_build /build/goon /anastasia/goon
 COPY --chown=ss13:ss13 --from=byond_build /build/html /anastasia/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN dpkg --add-architecture i386 \
     zlib1g:i386 \
     libstdc++6:i386 \
     && rm -rf /var/lib/apt/lists/*
-RUN useradd --uid 1002 --gid 1002 --create-home --shell /bin/bash ss13
+RUN useradd --uid 1002 --user-group --create-home --shell /bin/bash ss13
 COPY --chown=ss13:ss13 --from=byond_build /build/_maps /anastasia/_maps
 COPY --chown=ss13:ss13 --from=byond_build /build/goon /anastasia/goon
 COPY --chown=ss13:ss13 --from=byond_build /build/html /anastasia/html


### PR DESCRIPTION
When we provision the service account on the server, it gets a uid/gid of 1002:1002
`uid=1002(ss13) gid=1002(ss13) groups=1002(ss13)`

So we want the uid/gid of the container user to match.
This way we don't get permissions errors when we do the volume mount.

Alternatively, we could make the volume mounts world writable.
What could possibly go wrong? :yolo:

